### PR TITLE
Remove the user_id remapping from the lytics integration

### DIFF
--- a/lib/lytics/index.js
+++ b/lib/lytics/index.js
@@ -68,8 +68,7 @@ Lytics.prototype.page = function(page){
  */
 
 Lytics.prototype.identify = function(identify){
-  var traits = identify.traits({ userId: '_uid' });
-  window.jstag.send(traits);
+  window.jstag.send(identify.traits());
 };
 
 /**

--- a/lib/lytics/test.js
+++ b/lib/lytics/test.js
@@ -98,7 +98,7 @@ describe('Lytics', function(){
 
       it('should send an id', function(){
         analytics.identify('id');
-        analytics.called(window.jstag.send, { _uid: 'id', id: 'id' });
+        analytics.called(window.jstag.send, { id: 'id' });
       });
 
       it('should send traits', function(){
@@ -108,7 +108,7 @@ describe('Lytics', function(){
 
       it('should send an id and traits', function(){
         analytics.identify('id', { trait: true });
-        analytics.called(window.jstag.send, { _uid: 'id', trait: true, id: 'id' });
+        analytics.called(window.jstag.send, { trait: true, id: 'id' });
       });
     });
 


### PR DESCRIPTION
By having `user_id` mapped to `_uid` we were overriding the device id, which meant we had no means to map existing users to new devices to merge entities.
