### PR TITLE
Report page name as _e rather than name

### DIFF
--- a/lib/lytics/index.js
+++ b/lib/lytics/index.js
@@ -58,7 +58,10 @@ Lytics.prototype.loaded = function(){
  */
 
 Lytics.prototype.page = function(page){
-  window.jstag.send(page.properties());
+  var props = page.properties();
+  props._e = props.name;
+  delete props.name;
+  window.jstag.send(props);
 };
 
 /**

--- a/lib/lytics/test.js
+++ b/lib/lytics/test.js
@@ -79,8 +79,9 @@ describe('Lytics', function(){
       });
 
       it('should call send', function(){
-        analytics.page({ property: true });
+        analytics.page('Page Name', { property: true });
         analytics.called(window.jstag.send, {
+          _e: 'Page Name',
           property: true,
           path: window.location.pathname,
           referrer: document.referrer,


### PR DESCRIPTION
The name property is reserved for entity names. Referring to page
names as name results in an unwanted entity merge.
