### PR TITLE
Map userId to user_id

### DIFF
--- a/lib/lytics/index.js
+++ b/lib/lytics/index.js
@@ -72,7 +72,9 @@ Lytics.prototype.page = function(page){
  */
 
 Lytics.prototype.identify = function(identify){
-  window.jstag.send(this.options.stream, identify.traits());
+  window.jstag.send(this.options.stream, identify.traits({
+    userId: 'user_id'
+  }));
 };
 
 /**

--- a/lib/lytics/test.js
+++ b/lib/lytics/test.js
@@ -99,7 +99,7 @@ describe('Lytics', function(){
 
       it('should send an id', function(){
         analytics.identify('id');
-        analytics.called(window.jstag.send, 'default', { id: 'id' });
+        analytics.called(window.jstag.send, 'default', { user_id: 'id', id: 'id' });
       });
 
       it('should send traits', function(){
@@ -109,7 +109,7 @@ describe('Lytics', function(){
 
       it('should send an id and traits', function(){
         analytics.identify('id', { trait: true });
-        analytics.called(window.jstag.send, 'default', { trait: true, id: 'id' });
+        analytics.called(window.jstag.send, 'default', { trait: true, user_id: 'id', id: 'id' });
       });
     });
 


### PR DESCRIPTION
userId is conceptually a strong reference to a user entity. Lytics calls
this user_id.

Compare to _uid, which is a weak reference to a cookie.